### PR TITLE
WebDAV support and WifiManager portal

### DIFF
--- a/Controller/ESPIcialWebDAV.cpp
+++ b/Controller/ESPIcialWebDAV.cpp
@@ -1,0 +1,62 @@
+/*
+    ESP8266WebServer.h - Dead simple web-server.
+    Supports only one simultaneous client, knows how to handle GET and POST.
+
+    Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+    Simplified/Adapted for ESPWebDav:
+    Copyright (c) 2018 Gurpreet Bal https://github.com/ardyesp/ESPWebDAV
+    Copyright (c) 2020 David Gauchard https://github.com/d-a-v/ESPWebDAV
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+    Modified 8 May 2015 by Hristo Gochkov (proper post and file upload handling)
+*/
+
+#include "ESPIcialWebDAV.h"
+
+bool ESPIcialWebDAV::parseRequest()
+{
+    if (activityFn)
+      activityFn("ESPIcialWebDAV::parseRequest");
+
+    return ESPWebDAV::parseRequest();
+}
+
+void ESPIcialWebDAV::handleClient()
+{
+    if (!server)
+        return;
+
+    if (server->hasClient())
+    {
+        if (!locClient || !locClient.available())
+        {
+            // no or sleeping current client
+            // take it over
+            locClient = server->accept();
+            m_persistent_timer_ms = millis();
+            DBG_PRINT("NEW CLIENT-------------------------------------------------------");
+        }
+    }
+
+    if (!locClient || !locClient.available())
+        return;
+
+    // extract uri, headers etc
+    parseRequest();
+
+    if (!m_persistent)
+        // close the connection
+        locClient.stop();
+}

--- a/Controller/ESPIcialWebDAV.h
+++ b/Controller/ESPIcialWebDAV.h
@@ -1,0 +1,25 @@
+#ifndef __ESPICIALWEBDAV_H
+#define __ESPICIALWEBDAV_H
+
+#include <ESPWebDAV.h>
+
+class ESPIcialWebDAV: public ESPWebDAV
+{
+public:
+
+    using ActivityCallback = std::function<void(const char* request)>;
+    void setActivityCallback(const ActivityCallback& cb)
+    {
+        activityFn = cb;
+    }
+
+    void handleClient();
+
+protected:
+
+    bool parseRequest();
+
+    ActivityCallback activityFn = nullptr;
+};
+
+#endif // __ESPICIALWEBDAV_H


### PR DESCRIPTION
This adds WebDAV support in a way that the VERA FPGA/X16 and the ESPI can use the SD card in a shared way.
Whenever the ESPI (=connecte WiFi client) requests something from/to the SD card the SPI bus is switched to the ESPI's webDAV server.
After 5 seconds access is handed back to the FPGA (=X16).

The WifiManager provides an AP portal which let's users select a WiFi Network and enter the needed password.

If a file named "RESETWIFI" is present on the SD card, any WiFi credentials are removed and the AP portal is presented.

After establishing connection to a WiFi an additional power cycle might be needed.